### PR TITLE
allow passing context to using* functions

### DIFF
--- a/lib/TdmConnection.js
+++ b/lib/TdmConnection.js
@@ -110,17 +110,19 @@ TdmConnection.prototype.request = function * (sql, params, options)
 	return result;
 };
 
-TdmConnection.prototype.usingTransaction = function * (isolationLevel, name, scope)
+TdmConnection.prototype.usingTransaction = function * (isolationLevel, name, scope, ctx)
 {
 	if (typeof scope !== 'function')
 	{
 		if (typeof name === 'function')
 		{
+			ctx = scope;
 			scope = name;
 			name = undefined;
 		}
 		else
 		{
+			ctx = scope;
 			scope = isolationLevel;
 			name = undefined;
 			isolationLevel = undefined;
@@ -133,7 +135,7 @@ TdmConnection.prototype.usingTransaction = function * (isolationLevel, name, sco
 	
 	try
 	{
-		yield scope(tran);
+		yield scope.call(ctx, tran);
 	}
 	catch (ex)
 	{

--- a/lib/TdmConnection.js
+++ b/lib/TdmConnection.js
@@ -122,7 +122,7 @@ TdmConnection.prototype.usingTransaction = function * (isolationLevel, name, sco
 		}
 		else
 		{
-			ctx = scope;
+			ctx = name;
 			scope = isolationLevel;
 			name = undefined;
 			isolationLevel = undefined;

--- a/lib/TdmConnectionPool.js
+++ b/lib/TdmConnectionPool.js
@@ -146,12 +146,12 @@ TdmConnectionPool.prototype.trim = function ()
 	}
 };
 
-TdmConnectionPool.prototype.using = function * (scope)
+TdmConnectionPool.prototype.using = function * (scope, ctx)
 {
 	var c = yield this.acquire();
 	try
 	{
-		yield scope(c);
+		yield scope.call(ctx, c);
 		this.release(c);
 	}
 	catch (ex)
@@ -162,10 +162,10 @@ TdmConnectionPool.prototype.using = function * (scope)
 	}
 };
 
-TdmConnectionPool.prototype.usingTransaction = function * (isolationLevel, name, scope)
+TdmConnectionPool.prototype.usingTransaction = function * (isolationLevel, name, scope, ctx)
 {
 	yield this.using(/**@param db {TdmConnection}*/function * (db)
 	{
-		yield db.usingTransaction(isolationLevel, name, scope);
+		yield db.usingTransaction(isolationLevel, name, scope, ctx);
 	});
 };


### PR DESCRIPTION
Lemme know what you think. This shouldn't interfere with using `.bind(ctx)`, right?
