### PR TITLE
Don't rollback transactions twice

### DIFF
--- a/lib/TdmConnection.js
+++ b/lib/TdmConnection.js
@@ -138,6 +138,7 @@ TdmConnection.prototype.usingTransaction = function * (isolationLevel, name, sco
 	let tran = yield TdmTransaction.createTransaction(this, isolationLevel, name);
 	let error = null;
 	let result;
+	let isRequestError = false;
 	
 	try
 	{
@@ -146,9 +147,10 @@ TdmConnection.prototype.usingTransaction = function * (isolationLevel, name, sco
 	catch (ex)
 	{
 		error = ex;
+		isRequestError = ex.constructor && ex.constructor.name === 'RequestError';
 	}
 	
-	if (tran.open)
+	if (tran.open && (!isRequestError || (isRequestError && !tran.connection.tediousConnection.config.options.abortTransactionOnError)))
 		yield tran.rollback();
 	
 	if (error)


### PR DESCRIPTION
With the newly introduced support of `XACT_ABORT` in tedious (see https://github.com/pekim/tedious/issues/193), the transactions are automatically rollbacked when the `options.abortTransactionOnError` flag is set. 

This commit ensures Tedium doesn't attempt to manually rollback transactions that have already been rolled back automatically.

This also ensures that the error that is thrown by Tedium is not about rollbacking a second time (ie `The ROLLBACK TRANSACTION request has no corresponding BEGIN TRANSACTION`). Instead, the error thrown is about the invalid request within the transaction.
